### PR TITLE
Added Tavern Squad Wyrmstone token data

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -691,5 +691,14 @@
       "website": "https://www.adaverse.cc",
       "twitter": "https://twitter.com/AdaverseX"
     }
+  },
+  "4ffaa4ef3217df37c4995bb96066af4cb68dfcc66b9f2a10e0c333b9": {
+    "project": "Tavern Squad",
+    "categories": ["NFT", "GameFi"],
+    "socialLinks": {
+      "website": "https://tavernsquad.io/",
+      "twitter": "https://twitter.com/TavernSquadNFT",
+      "discord": "https://discord.gg/tavernsquad"
+    }
   }
 }


### PR DESCRIPTION
Added Tavern Squad Wyrmstone token data. 

Wyrmstone policy ID can be found on homepage of the submitted website. Please scroll all the way down the homepage to find it. Thanks!