### PR TITLE
Add Paribus (PBX) token

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -2220,5 +2220,17 @@
       "twitter": "https://twitter.com/mannequinsnft",
       "discord": "https://discord.gg/ArtGUbuVHw"
     }
+  },
+  "cc8d1b026353022abbfcc2e1e71159f9e308d9c6e905ac1db24c7fb6": {
+    "project": "Paribus",
+    "categories": ["DeFi", "NFT"],
+    "socialLinks": {
+      "website": "https://paribus.io",
+      "twitter": "https://twitter.com/paribus_io",
+      "discord": "https://discord.gg/paribus",
+      "telegram": "https://t.me/paribus_io",
+      "coinMarketCap": "https://coinmarketcap.com/currencies/paribus",
+      "coinGecko": "https://www.coingecko.com/en/coins/paribus"
+    }
   }
 }


### PR DESCRIPTION
This MR is to add Paribus (PBX) token to the verified tokens list.

To verify that I'm authorized to do this request: 

- I added the token to the Cardano Token Registry: https://github.com/cardano-foundation/cardano-token-registry/pull/2572
- You can find the policyId on our website on the first view bottom left: https://paribus.io/

