### PR TITLE
Add the Linkage Finance Token policy

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -2324,5 +2324,14 @@
       "discord": "https://discord.gg/XgVmTAFw",
       "telegram": "https://t.me/+hzARUQpOKgI1MjJh"
     }
+  },
+  "7914fae20eb2903ed6fd5021a415c1bd2626b64a2d86a304cb40ff5e": {
+    "project": "Linkage Finance",
+    "categories": ["DeFi"],
+    "socialLinks": {
+      "website": "https://linkage.finance",
+      "twitter": "https://twitter.com/LinkageFinance/",
+      "telegram": "https://t.me/linkagefi",
+    }
   }
 }


### PR DESCRIPTION
The token is not yet in circulation and hence has no pool yet. All other tokens traded on MinSwap until now and associated with Linkage Finance are a scam.