### PR TITLE
add CRS to verified tokens

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -2324,5 +2324,14 @@
       "discord": "https://discord.gg/XgVmTAFw",
       "telegram": "https://t.me/+hzARUQpOKgI1MjJh"
     }
+  },
+  "683ad3ec68eaf2924cd616d3b2580991a4db62d75f1ad5ae473314d4": {
+    "project": "CRS",
+    "categories": ["GameFi"],
+    "socialLinks": {
+      "website": "https://speedthrone.io/",
+      "twitter": "https://twitter.com/SpeedThrone",
+      "discord": "http://discord.gg/WvfB8NFwGt"
+    }
   }
 }


### PR DESCRIPTION
This PR adds CRS (CrownShards) which is a GameFI community token for the Cardano NFT game SpeedThrone.

There are plenty of mentions of CRS in the twitter feed of the official twitter account; https://twitter.com/SpeedThrone