### PR TITLE
Add the new MILK v2 verified tokens token to MinSwap

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -87,6 +87,18 @@
       "coinGecko": "https://www.coingecko.com/en/coins/muesliswap-milk"
     }
   },
+  "afbe91c0b44b3040e360057bf8354ead8c49c4979ae6ab7c4fbdc9eb": {
+    "project": "MuesliSwap",
+    "categories": ["DeFi"],
+    "socialLinks": {
+      "website": "https://muesliswap.com",
+      "discord": "https://discord.gg/VG7fWHvHSM",
+      "telegram": "https://t.me/muesliswapADA",
+      "twitter": "https://twitter.com/MuesliSwapTeam",
+      "coinMarketCap": "https://coinmarketcap.com/currencies/muesliswap/",
+      "coinGecko": "https://www.coingecko.com/en/coins/muesliswap-milk"
+    }
+  },
   "1d7f33bd23d85e1a25d87d86fac4f199c3197a2f7afeb662a0f34e1e": {
     "project": "World Mobile Token",
     "categories": ["RealFi"],


### PR DESCRIPTION
The new MuesliSwap MILK token has a new policy id that includes locking. There will be a respective pool for the new token on MinSwap, if required, the verification can be delayed until the pool exists.