### PR TITLE
Add rsBTC: Rosen Bridge

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -3824,5 +3824,16 @@
       "website": "https://linktr.ee/chairmanmeow",
       "twitter": "https://x.com/ChairmanMeowAda"
     }
+      },
+  "2dbc49f682ad21f6d18705cf446f9f7a277731ab70ae21a454f888b2": {
+    "project": "Rosen Bridge rsBTC",
+    "categories": ["Bridge", "Other"],
+    "socialLinks": {
+      "website": "https://rosen.tech/",
+      "twitter": "https://twitter.com/RosenBridge_erg",
+      "discord": "https://discord.com/invite/AHgsxhDKrQ",
+      "telegram": "https://t.me/rosenbridge_erg",
+      "coinGecko": "https://www.coingecko.com/en/coins/rosen-bridge"
+    }
   }
 }


### PR DESCRIPTION
Add rsBTC policyID. This is in addition to existing Rosen Bridge assets already verified, for example under policy ID:
04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14

Cross-reference the rsBTC Policy ID via our GitHub: 
https://github.com/rosen-bridge/contract/blob/827258102d7ed8cc0147e5f7e847e4ade8e600c2/tokensMap/BTC.mainnet-public-launch.json#L13