### PR TITLE
Added PBG Token

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -4116,5 +4116,14 @@
       "telegram": "https://t.me/+7ndbw5QA7ppkOGFk",
       "twitter": "https://x.com/mom_on_ada"
     }
+  },
+  "03b6ddacd60cc1ebd9ed4041d0c298c4c6f48ab61e04fdad4d915cfa": {
+    "project": "PBG",
+    "categories": ["DeFi"],
+    "socialLinks": {
+      "website": "https://pbg.io",
+      "discord": "https://discord.gg/gpwCJmYCBN",
+      "twitter": "https://x.com/PBGToken"
+    }
   }
 }


### PR DESCRIPTION
Added PBG Token with policy ID 03b6ddacd60cc1ebd9ed4041d0c298c4c6f48ab61e04fdad4d915cfa

Many different asset classes exist with the given policy ID, but only one operates as a regular token and thus only one asset class with this policy ID matters for DEXes: asset14u343978h4nc9euau4a9xl29lx8ssepqy4qfx9